### PR TITLE
[BUGFIX] Field no longer required when presence is disabled

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -15,7 +15,13 @@ export default BsFormElement.extend({
   hasValidator: computed.notEmpty('_attrValidations').readOnly(),
   hasErrors: computed.and('_attrValidations.isInvalid', 'notValidating').readOnly(),
   isValidating: computed.readOnly('_attrValidations.isValidating'),
-  required: computed.and('_attrValidations.options.presence.presence', 'notDisabled'),
+  // mark as required only if:
+  // - field is not disabled,
+  // - presence validator requires data presence
+  // - presence validator is not disabled
+  required: computed('_attrValidations.options.presence.presence', '_attrValidations.options.presence.disabled', 'notDisabled', function() {
+     return this.get('notDisabled') && this.get('_attrValidations.options.presence.presence') && !this.get('_attrValidations.options.presence.disabled')
+  }),
 
   setupValidations() {
     defineProperty(this, '_attrValidations', computed.readOnly(`model.validations.attrs.${this.get('property')}`));

--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -10,18 +10,18 @@ export default BsFormElement.extend({
   _attrValidations: null,
   notValidating: computed.not('isValidating').readOnly(),
   notDisabled: computed.not('disabled').readOnly(),
+  _presenceEnabled: computed.not('_attrValidations.options.presence.disabled'),
 
   // Overwrite
   hasValidator: computed.notEmpty('_attrValidations').readOnly(),
   hasErrors: computed.and('_attrValidations.isInvalid', 'notValidating').readOnly(),
   isValidating: computed.readOnly('_attrValidations.isValidating'),
+
   // mark as required only if:
   // - field is not disabled,
-  // - presence validator requires data presence
-  // - presence validator is not disabled
-  required: computed('_attrValidations.options.presence.presence', '_attrValidations.options.presence.disabled', 'notDisabled', function() {
-     return this.get('notDisabled') && this.get('_attrValidations.options.presence.presence') && !this.get('_attrValidations.options.presence.disabled')
-  }),
+  // - presence validator requires presence
+  // - presence validator is enabled
+  required: computed.and('notDisabled', '_attrValidations.options.presence.presence', '_presenceEnabled'),
 
   setupValidations() {
     defineProperty(this, '_attrValidations', computed.readOnly(`model.validations.attrs.${this.get('property')}`));


### PR DESCRIPTION
Fixes issue with form element being marked as `required` even if `presence` validator` was disabled.