### PR TITLE
Updates for compatibility with ember-bootstrap 1.0 (alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1-13
+  - EMBER_TRY_SCENARIO=ember-2.4-lts
+  - EMBER_TRY_SCENARIO=ember-2.8-lts
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 ember install ember-bootstrap-cp-validations
 ```
 
+If using ember-bootstrap 1.0 (alpha), install the corresponding version of this addon:
+
+    ember install ember-bootstrap-cp-validations@1.0.0-alpha
+
 ## Usage
 
 Just install this addon and use ember-bootstrap as intended. This addon adds support for form validation (error and warning messages) of the following components

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import BsFormElement from 'ember-bootstrap/components/bs-form-element';
+import BsFormElement from 'ember-bootstrap/components/bs-form/element';
 
 const {
   computed,

--- a/app/components/bs-form-element.js
+++ b/app/components/bs-form-element.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-bootstrap-cp-validations/components/bs-form-element';

--- a/app/components/bs-form/element.js
+++ b/app/components/bs-form/element.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap-cp-validations/components/bs-form/element';

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,19 +2,18 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-2.4-lts',
       bower: {
-        dependencies: { }
+        dependencies: {
+          "ember": "~2.4.0"
+        }
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'ember-2.8-lts',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
+          "ember": "~2.8.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-bootstrap": "0.6.4",
+    "ember-bootstrap": "1.0.0-alpha",
     "ember-cli": "2.4.1",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -33,12 +33,13 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-cp-validations": "^2.6.1",
+    "ember-cp-validations": "^3.1.4",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.0",
+    "ember-polyfill-for-tests": "0.2.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
     "loader.js": "^4.0.0"

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   actions: {
     submit() {
-      alert('Form submitted!');
+      window.alert('Form submitted!');
     }
   }
 });

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -1,0 +1,76 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import startApp from '../../helpers/start-app';
+import destroyApp from '../../helpers/destroy-app';
+import { validator, buildValidations } from 'ember-cp-validations';
+
+const { getOwner, setOwner } = Ember;
+
+const Validations = buildValidations({
+  test: [
+    validator('presence', true)
+  ]
+});
+const Model = Ember.Object.extend(Validations, {
+  test: null
+});
+
+moduleForComponent('bs-form-element', 'Integration | Component | bs form element', {
+  integration: true
+});
+
+test('valid validation is supported as expected', function(assert) {
+  let App = startApp();
+  let model = Model.create({
+    test: '123'
+  });
+  setOwner(model, getOwner(this));
+
+  this.set('model', model);
+  this.on('submitAction', function() {
+    assert.ok(true, 'submit action has been called.');
+  });
+  this.on('invalidAction', function() {
+    assert.ok(false, 'Invalid action must not been called.');
+  });
+
+  this.render(hbs`
+    {{#bs-form model=model onSubmit=(action "submitAction") onInvalid=(action "invalidAction") as |form|}}
+      {{form.element label="test" property="test"}}
+    {{/bs-form}}
+  `);
+
+  assert.expect(1);
+
+  this.$('form').submit();
+
+  destroyApp(App);
+});
+
+test('invalid validation is supported as expected', function(assert) {
+  let App = startApp();
+  let model = Model.create();
+  setOwner(model, getOwner(this));
+
+  this.set('model', model);
+  this.on('submitAction', function() {
+    assert.ok(false, 'submit action must not been called.');
+  });
+  this.on('invalidAction', function() {
+    assert.ok(true, 'Invalid action has been called.');
+  });
+
+  this.render(hbs`
+    {{#bs-form model=model onSubmit=(action "submitAction") onInvalid=(action "invalidAction") as |form|}}
+      {{form.element label="test" property="test"}}
+    {{/bs-form}}
+  `);
+
+  assert.expect(2);
+
+  this.$('form').submit();
+  assert.ok(this.$('.form-group').hasClass('has-error'), 'form element group has error class');
+
+  destroyApp(App);
+});


### PR DESCRIPTION
Just released ember-bootstrap 1.0.0-alpha, that includes several breaking changes (see https://github.com/kaliber5/ember-bootstrap/blob/master/CHANGELOG.md). For the validation support, only the change to nested and contextual components for the former `bs-form-element` component is relevant. This includes the necessary updates. 

Added tests also, `ember-polyfill-for-tests` is need for PhantomJS, throws some strange exception otherwise.

I would suggest this to be released also as v1.0.0-alpha, so it is in-sync with e-b.