### PR TITLE
Ensure that buffered proxy objects don't fail unexpectedly when validating

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -10,7 +10,7 @@ export default BsForm.extend({
     return new EmberPromise((resolve, reject) => {
       let m = model;
 
-      if(model instanceof ObjectProxy) {
+      if(model instanceof ObjectProxy && model.get('content') && typeof model.get('content').validate === 'function') {
         m = model.get('content');
       }
 

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -72,7 +72,7 @@ module('Integration | Component | bs form element', function(hooks) {
   });
 
   test('valid validation is supported as expected when working with an ember-buffered-proxy model', async function(assert) {
-    let proxiedModel = Model.create();
+    let proxiedModel = EmberObject.create();
     setOwner(proxiedModel, this.owner);
 
     let model = BufferedModel.create({
@@ -101,7 +101,7 @@ module('Integration | Component | bs form element', function(hooks) {
   });
 
   test('invalid validation is supported as expected when working with an ember-buffered-proxy model', async function(assert) {
-    let proxiedModel = Model.create();
+    let proxiedModel = EmberObject.create();
     setOwner(proxiedModel, this.owner);
 
     let model = BufferedModel.create({

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import ObjectProxy from '@ember/object/proxy';
 import { setOwner } from '@ember/application';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -12,6 +13,9 @@ const Validations = buildValidations({
   ]
 });
 const Model = EmberObject.extend(Validations, {
+  test: null
+});
+const BufferedModel = ObjectProxy.extend(Validations, {
   test: null
 });
 
@@ -65,5 +69,62 @@ module('Integration | Component | bs form element', function(hooks) {
 
     await triggerEvent('form', 'submit');
     assert.ok(find('.form-group').classList.contains('has-error'), 'form element group has error class');
+  });
+
+  test('valid validation is supported as expected when working with an ember-buffered-proxy model', async function(assert) {
+    let proxiedModel = Model.create();
+    setOwner(proxiedModel, this.owner);
+
+    let model = BufferedModel.create({
+      content: proxiedModel,
+      test: '123'
+    });
+    setOwner(model, this.owner);
+
+    this.set('model', model);
+    this.submitAction = function() {
+      assert.ok(true, 'submit action has been called.');
+    };
+    this.invalidAction = function() {
+      assert.ok(false, 'Invalid action must not been called.');
+    };
+
+    await render(hbs`
+    {{#bs-form model=model onSubmit=(action submitAction) onInvalid=(action invalidAction) as |form|}}
+      {{form.element label="test" property="test"}}
+    {{/bs-form}}
+  `);
+
+    assert.expect(1);
+
+    await triggerEvent('form', 'submit');
+  });
+
+  test('invalid validation is supported as expected when working with an ember-buffered-proxy model', async function(assert) {
+    let proxiedModel = Model.create();
+    setOwner(proxiedModel, this.owner);
+
+    let model = BufferedModel.create({
+      content: proxiedModel
+    });
+    setOwner(model, this.owner);
+
+    this.set('model', model);
+    this.submitAction = function() {
+      assert.ok(false, 'submit action must not been called.');
+    };
+    this.invalidAction = function() {
+      assert.ok(true, 'Invalid action has been called.');
+    };
+
+    await render(hbs`
+    {{#bs-form model=model onSubmit=(action submitAction) onInvalid=(action invalidAction) as |form|}}
+      {{form.element label="test" property="test"}}
+    {{/bs-form}}
+  `);
+
+    assert.expect(1);
+
+    await triggerEvent('form', 'submit');
   });
 });


### PR DESCRIPTION
I've run into the same issue as described in #11. Specifically, the assumption that an `Ember.ObjectProxy` must be an Ember Data model doesn't hold if the form model in question is a `ember-buffered-proxy` model (that either holds data manually or wraps an Ember Data model).

This fix resolves things by checking for the `buffer` property that exists on an `ember-buffered-proxy` model and unwraps the object being proxied if we aren't dealing with a buffered proxy model.

Fixes #11 

@bluscreen would you mind checking this on your end to see if it resolves things for you?

_Note: there is one instance where this may be a breaking change. It is possible to work around this bug if the wrapped model - such as an Ember Data model - has at least one `ember-cp-validation` definition. In the app I'm working on, make these changes does not breaks tests for us, but it's possible it would affect others ... I'm inclined to risk it, as I'm not sure anyone else has hit this other than @bluscreen and me_ 😀