### PR TITLE
Verify model exists before testing a validator exists

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -8,7 +8,7 @@ export default class ValidatedBsFrom extends BsForm {
   '__ember-bootstrap_subclass' = true;
 
   get hasValidator() {
-    return !!this.model.validate;
+    return !!this.model?.validate;
   }
 
   async validate(model) {

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -150,4 +150,26 @@ module('Integration | Component | bs form element', function(hooks) {
 
     await triggerEvent('form', 'submit');
   });
+
+  test('error is not generated when a model is not supplied when component.formElements are not used ', async function(assert) {
+    let name;
+    this.set('name', name);
+    
+    this.submitAction = function() {
+      assert.ok(true, 'submit action called.');
+    };
+    this.invalidAction = function() {
+      assert.ok(true, 'Invalid action has been called.');
+    };
+
+    await render(hbs`
+      <BsForm @onSubmit={{this.submitAction}} @onInvalid={{this.invalidAction}}>
+        <Input @type="text" @value={{this.name}} />
+      </BsForm>
+    `);
+
+    assert.expect(1);
+
+    await triggerEvent('form', 'submit');
+  });
 });


### PR DESCRIPTION
@simonihmig 

When using `BsForm` without `Component.formElement`'s and `@model` the `hasValidator` getter generates an error because `this.model` does not exist.

The fix below and a test was added. Optional chaining has been available since Ember 3.15

```js
  get hasValidator() {
    return !!this.model?.validate;
  }
```